### PR TITLE
Fix "Teach Yourself CS" hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Collection of resources for programmers!
 
 If you are starting out and want to follow a curriculum for CS, you can check out the follow resources:
 
-- [Teach Yourself CS](teachyourselfcs.com)
+- [Teach Yourself CS](https://teachyourselfcs.com/)
 - [OSSU CS](https://github.com/ossu/computer-science)
 
 ## Table of contents


### PR DESCRIPTION
The "Teach Yourself CS" hyperlink led to a 404 - not found page, so I updated the link.